### PR TITLE
已修復數量變成負數的問題。

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -113,9 +113,11 @@ class TransactionsController < ApplicationController
 
   def decrease_donate_amount(donate_item_title, amount)
     donate_item = DonateItem.find_by!(title: donate_item_title)
-    donate_item.with_lock do
-      donate_item.decrement(:amount, amount.to_i)
-      donate_item.save
+    if donate_item.amount != nil
+      donate_item.with_lock do
+        donate_item.decrement(:amount, amount.to_i)
+        donate_item.save
+      end
     end
   end
 end


### PR DESCRIPTION
找到問題了。
如果一開始建立贊助時，沒有設定數量，數量的值會是 nil。
view 對數量的設定是 <%= donate_item.amount %> if donate_item.amount
所以沒設定(nil)就不會顯示數量，正常沒錯。
但經過交易後，會透過 decrease_donate_amount 方法去減少數量，當 amount 沒設定為 nil 時，就會被變成 -X。
於是增加 if donate_item.amount != nil 的條件，意思就是，有設定數量才會去扣數量，沒設定數量就不會去執行減法。
